### PR TITLE
Copy line from instructions in example repo.

### DIFF
--- a/src/routes/020_Getting_Started/010_Installation.md
+++ b/src/routes/020_Getting_Started/010_Installation.md
@@ -40,6 +40,7 @@ In the following the root of your project will be indicated with '~'.
 
 *	Open another (bash) terminal, and start the generated editor from it:
     ```bash
+    yarn prepare-app   # Needed to generate the runtime CSS files.
     yarn dev
     ```
      


### PR DESCRIPTION
Added line needed for the styling to work. Couldn't build the site with `yarn run build`, though, due to this:
```
> Using @sveltejs/adapter-static
> Cannot read properties of undefined (reading 'kit')
    at adapt (file:///Users/meinte/Documents/Git/ProjectIt-documentation/node_modules/@sveltejs/adapter-static/index.js:16:46)
    at adapt (file:///Users/meinte/Documents/Git/ProjectIt-documentation/node_modules/@sveltejs/kit/dist/chunks/index5.js:857:8)
    at file:///Users/meinte/Documents/Git/ProjectIt-documentation/node_modules/@sveltejs/kit/dist/cli.js:1062:11
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```